### PR TITLE
增加 dnmp sh

### DIFF
--- a/.bashrc.wsl.sample
+++ b/.bashrc.wsl.sample
@@ -1,0 +1,78 @@
+composer_win_path='D:\dnmp\data\composer'
+www_wsl_path='/mnt/d/www'
+www_win_path='D:\www'
+
+# dnmp alias
+alias dnginx='docker exec -it nginx /bin/sh'
+alias dphp='docker exec -it php /bin/sh'
+alias dmysql='docker exec -it mysql /bin/bash'
+
+# dnmp 设置
+docker() {
+    # 调用 docker.exe，并传入参数
+    docker.exe "$@"
+}
+
+docker-compose() {
+    # 调用 docker-compose.exe， 并传入参数
+    docker-compose.exe "$@"
+}
+
+pwd-win() {
+
+    win_dir=$(wslpath -w $(pwd))
+
+    chr=$(expr substr "$win_dir" 2 1)
+
+    if [ "$chr" = ":" ]; then
+        echo "$win_dir"
+    else
+        echo "$www_win_path"
+    fi
+}
+
+php-run() {
+    docker run \
+        -it \
+        --rm \
+        --user www-data:www-data \
+        --volume $(pwd-win):/www:rw \
+        --workdir /www \
+        dnmp_php "$@"
+}
+
+php-exec() {
+    docker exec \
+        -it \
+        --user www-data:www-data \
+        --volume $(pwd-win):/tmp/app \
+        --workdir /tmp/app \
+        php "$@"
+}
+
+php-sh() {
+    if [[ $PWD =~ "$www_wsl_path" ]]; then
+        php-exec "$@"
+    else
+        php-run "$@"
+    fi
+}
+
+laravel() {
+    php-sh laravel "$@"
+}
+
+php() {
+    php-sh php "$@"
+}
+
+composer() {
+    docker run \
+        -it \
+        --rm \
+        --user www-data:www-data \
+        --volume "$composer_win_path":/tmp/composer \
+        --volume $(pwd-win):/app \
+        --workdir /app \
+        dnmp_php composer "$@"
+}

--- a/dnmp
+++ b/dnmp
@@ -1,0 +1,67 @@
+#!/bin/bash
+#
+DNMP_DIR=$(cd `dirname $(readlink -f $0)`; pwd)
+
+source ${DNMP_DIR}/.env
+
+SOURCE_ABS_DIR=$(cd ${DNMP_DIR}/${SOURCE_DIR}; pwd)
+
+phpRun () {
+    tty=
+    tty -s && tty=--tty
+    docker run \
+        $tty \
+        --interactive \
+        --rm \
+        --volume $PWD:/www:rw \
+        --workdir /www \
+        dnmp_php php "$@"
+}
+
+phpExec () {
+    docker exec \
+            -it \
+            -w ${PWD/${SOURCE_ABS_DIR}/\/www} \
+            php php "$@"
+}
+
+php () {
+    if [[ $PWD =~ "${SOURCE_ABS_DIR}" ]]; then
+        phpExec "$@"
+    else
+        phpRun "$@"
+    fi
+}
+
+# php7 composer
+composer () {
+    tty=
+    tty -s && tty=--tty
+    docker run \
+        $tty \
+        --interactive \
+        --rm \
+        --user www-data:www-data \
+        --volume ${DNMP_DIR}/data/composer:/tmp/composer \
+        --volume $(pwd):/app \
+        --workdir /app \
+        dnmp_php composer "$@"
+}
+
+    
+while :; do 
+    [ -z "$1" ] && break;
+    case "$1" in
+        php)
+            shift 1
+            php "$@"; exit 0
+            ;;
+        composer)
+            shift 1
+            composer "$@"; exit 0
+            ;;
+        *)
+            echo "${CWARNING}ERROR: unknown argument! ${CEND}" &&  exit 1
+            ;;
+    esac
+done

--- a/dnmp
+++ b/dnmp
@@ -61,7 +61,7 @@ while :; do
             composer "$@"; exit 0
             ;;
         *)
-            echo "${CWARNING}ERROR: unknown argument! ${CEND}" &&  exit 1
+            echo "ERROR: unknown argument! " &&  exit 1
             ;;
     esac
 done

--- a/services/php/Dockerfile
+++ b/services/php/Dockerfile
@@ -30,6 +30,7 @@ ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so php
 RUN curl -o /usr/bin/composer https://mirrors.aliyun.com/composer/composer.phar \
     && chmod +x /usr/bin/composer
 ENV COMPOSER_HOME=/tmp/composer
+ENV PATH="/tmp/composer/vendor/bin:${PATH}"
 
 
 # php image's www-data user uid & gid are 82, change them to 1000 (primary user)


### PR DESCRIPTION
增加 dnmp sh, 可以 ln -s 到 path 后直接使用容器内命令。

暂时有
PHP 如： ``` dnmp php -v ```
composer 如： ``` dnmp composer -v ```

#### 切记，可 ln -s 到PATH, 或在 dnmp 目录下使用，不能从 dnmp 目录下移走。