### PR TITLE
优化减小生成的php-fpm镜像大小

### DIFF
--- a/services/php/extensions/install.sh
+++ b/services/php/extensions/install.sh
@@ -15,7 +15,7 @@ echo
 
 
 if [ "${PHP_EXTENSIONS}" != "" ]; then
-    apk add --no-cache autoconf g++ libtool make curl-dev gettext-dev linux-headers
+    apk --update add --no-cache --virtual .build-deps autoconf g++ libtool make curl-dev gettext-dev linux-headers
 fi
 
 
@@ -199,9 +199,21 @@ fi
 
 if [[ -z "${EXTENSIONS##*,gd,*}" ]]; then
     echo "---------- Install gd ----------"
-    apk add --no-cache freetype-dev libjpeg-turbo-dev libpng-dev \
-    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install ${MC} gd
+    apk add --no-cache \
+        freetype \
+        freetype-dev \
+        libpng \
+        libpng-dev \
+        libjpeg-turbo \
+        libjpeg-turbo-dev \
+    && docker-php-ext-configure gd \
+        --with-freetype-dir=/usr/include/ \
+        --with-jpeg-dir=/usr/include/ \
+    && docker-php-ext-install ${MC} gd \
+    && apk del \
+        freetype-dev \
+        libpng-dev \
+        libjpeg-turbo-dev
 fi
 
 if [[ -z "${EXTENSIONS##*,intl,*}" ]]; then
@@ -542,4 +554,9 @@ if [[ -z "${EXTENSIONS##*,xlswriter,*}" ]]; then
     else
         echo "---------- PHP Version>= 7.0----------"
     fi
+fi
+
+if [ "${PHP_EXTENSIONS}" != "" ]; then
+    apk del .build-deps \
+    && docker-php-source delete
 fi


### PR DESCRIPTION
测试显示构建的php-fpm镜像大小从300~400mb减小到100mb左右