### PR TITLE
加上 --with-freetype-dir=DIR ，gd 库激活 FreeType 2 的支持

### DIFF
--- a/services/php/extensions/install.sh
+++ b/services/php/extensions/install.sh
@@ -207,6 +207,10 @@ if [[ -z "${EXTENSIONS##*,gd,*}" ]]; then
         libjpeg-turbo \
         libjpeg-turbo-dev \
     && docker-php-ext-configure gd \
+        --with-gd \
+        --with-freetype-dir=/usr/include/ \
+        --with-png-dir=/usr/include/ \
+        --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install ${MC} gd \
     && apk del \
         freetype-dev \


### PR DESCRIPTION
# 修改前：gd 库不支持 freetype
![image](https://user-images.githubusercontent.com/16890747/72587398-16aef680-3930-11ea-8fd5-63e40c2f493f.png)

# 修改后：gd 库支持 freetype
![image](https://user-images.githubusercontent.com/16890747/72587370-fc751880-392f-11ea-9381-8b7358076d75.png)
