### PR TITLE
修复缺少libstdc++的bug

### DIFF
--- a/services/php/Dockerfile
+++ b/services/php/Dockerfile
@@ -22,7 +22,7 @@ RUN apk --no-cache add tzdata \
 
 
 # Fix: https://github.com/docker-library/php/issues/240
-RUN apk add gnu-libiconv --no-cache --repository http://${CONTAINER_PACKAGE_URL}/alpine/edge/community/ --allow-untrusted
+RUN apk add gnu-libiconv libstdc++ --no-cache --repository http://${CONTAINER_PACKAGE_URL}/alpine/edge/community/ --allow-untrusted
 ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so php
 
 


### PR DESCRIPTION
修复缺少libstdc++的bug，mac中安装swoole 4.4会报错，Error loading shared library libstdc++.so.6: No such file or directory (needed by /usr/local/lib/php/extensions/no-debug-non-zts-20190902/swoole.so)