### PR TITLE
更新PHP版本以修复读取数据库精度问题

### DIFF
--- a/env.sample
+++ b/env.sample
@@ -83,7 +83,7 @@ SUPERVISOR_HOST_PORT_C=9001
 # or install multi plugins as:
 # PHP_EXTENSIONS=pdo_mysql,mysqli,gd,curl,opcache
 #
-PHP_VERSION=7.4.1
+PHP_VERSION=7.4.7
 PHP_PHP_CONF_FILE=./services/php/php.ini
 PHP_FPM_CONF_FILE=./services/php/php-fpm.conf
 PHP_LOG_DIR=./logs/php


### PR DESCRIPTION
https://github.com/yeszao/dnmp/issues/272
根据issues中的测试代码进行测试
设置数据库中的值为0.9393
PHP7.4.7版本输出：MySQL服务器版本：Array ( [id] => 1 [0] => 1 [value] => 0.9393 [1] => 0.9393 ) 8.0.20
PHP7.4.1版本输出：MySQL服务器版本：Array ( [id] => 1 [0] => 1 [value] => 0.9394 [1] => 0.9394 ) 8.0.20

PHP7.4.1版本输出为0.9394
PHP7.4.7版本输出为0.9393
看样子这个问题应该是已经修复了。
您可以再测试一下。