### PR TITLE
CONTAINER_PACKAGE_URL 为空或不存在时，不要执行替换

### DIFF
--- a/services/php/Dockerfile
+++ b/services/php/Dockerfile
@@ -6,7 +6,7 @@ ARG PHP_EXTENSIONS
 ARG CONTAINER_PACKAGE_URL
 
 
-RUN sed -i "s/dl-cdn.alpinelinux.org/${CONTAINER_PACKAGE_URL}/g" /etc/apk/repositories
+RUN if [ $CONTAINER_PACKAGE_URL ] ; then sed -i "s/dl-cdn.alpinelinux.org/${CONTAINER_PACKAGE_URL}/g" /etc/apk/repositories ; fi
 
 
 COPY ./extensions /tmp/extensions


### PR DESCRIPTION
国外服务使用，删除CONTAINER_PACKAGE_URL时或修改为空时，报错，pr修复问题