### PR TITLE
修改elasticsearch 启动报错,issue#316

### DIFF
--- a/services/elasticsearch/elasticsearch.yml
+++ b/services/elasticsearch/elasticsearch.yml
@@ -5,5 +5,3 @@ network.host: 0.0.0.0
 # set to 1 to allow single node clusters
 # Details: https://github.com/elastic/elasticsearch/pull/17288
 discovery.zen.minimum_master_nodes: 1
-
-index.analysis.analyzer.default.type: standard


### PR DESCRIPTION
启动elasticsearch报错 
`
"at org.elasticsearch.bootstrap.Elasticsearch.init(Elasticsearch.java:163) ~[elasticsearch-7.1.1.jar:7.1.1]",
elasticsearch    | "at org.elasticsearch.bootstrap.Elasticsearch.execute(Elasticsearch.java:150) ~[elasticsearch-7.1.1.jar:7.1.1]",
elasticsearch    | "at org.elasticsearch.cli.EnvironmentAwareCommand.execute(EnvironmentAwareCommand.java:86) ~[elasticsearch-7.1.1.jar:7.1.1]",
elasticsearch    | "at org.elasticsearch.cli.Command.mainWithoutErrorHandling(Command.java:124) ~[elasticsearch-cli-7.1.1.jar:7.1.1]",
elasticsearch    | "at org.elasticsearch.cli.Command.main(Command.java:90) ~[elasticsearch-cli-7.1.1.jar:7.1.1]",
elasticsearch    | "at org.elasticsearch.bootstrap.Elasticsearch.main(Elasticsearch.java:115) ~[elasticsearch-7.1.1.jar:7.1.1]",
elasticsearch    | "at org.elasticsearch.bootstrap.Elasticsearch.main(Elasticsearch.java:92) ~[elasticsearch-7.1.1.jar:7.1.1]",
elasticsearch    | "Caused by: java.lang.IllegalArgumentException: node settings must not contain any index level settings",
elasticsearch    | "at org.elasticsearch.common.settings.SettingsModule.<init>(SettingsModule.java:142) ~[elasticsearch-7.1.1.jar:7.1.1]",
elasticsearch    | "at org.elasticsearch.node.Node.<init>(Node.java:343) ~[elasticsearch-7.1.1.jar:7.1.1]",
elasticsearch    | "at org.elasticsearch.node.Node.<init>(Node.java:252) ~[elasticsearch-7.1.1.jar:7.1.1]",
elasticsearch    | "at org.elasticsearch.bootstrap.Bootstrap$5.<init>(Bootstrap.java:211) ~[elasticsearch-7.1.1.jar:7.1.1]",
elasticsearch    | "at org.elasticsearch.bootstrap.Bootstrap.setup(Bootstrap.java:211) ~[elasticsearch-7.1.1.jar:7.1.1]",
elasticsearch    | "at org.elasticsearch.bootstrap.Bootstrap.init(Bootstrap.java:325) ~[elasticsearch-7.1.1.jar:7.1.1]",
elasticsearch    | "at org.elasticsearch.bootstrap.Elasticsearch.init(Elasticsearch.java:159) ~[elasticsearch-7.1.1.jar:7.1.1]",
elasticsearch    | "... 6 more"] }
`