### PR TITLE
MySQL支持Arm CPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ install-php-extensions apcu
             "packagist": {
                 "type": "composer",
                 "url": "https://mirrors.aliyun.com/composer/"
-s            }
+            }
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-DNMP（Docker + Nginx + MySQL + PHP7/5 + Redis）是一款全功能的**LNMP一键安装程序**。
+DNMP（Docker + Nginx/Openresty + MySQL5,8 + PHP5,7,8 + Redis + ElasticSearch + MongoDB + RabbitMQ）是一款全功能的**LNMP一键安装程序，支持Arm CPU**。
 
 > 使用前最好提前阅读一遍[目录](#目录)，以便快速上手，遇到问题也能及时排除。
 
@@ -14,14 +14,14 @@ QQ交流群：
 DNMP项目特点：
 1. `100%`开源
 2. `100%`遵循Docker标准
-3. 支持**多版本PHP**共存，可任意切换（PHP5.4、PHP5.6、PHP7.1、PHP7.2、PHP7.3、PHP8.0)
+3. 支持**多版本PHP**共存，可任意切换（PHP5.4、PHP5.6、PHP7.1、PHP7.2、PHP7.3、PHP7.4、PHP8.0)
 4. 支持绑定**任意多个域名**
 5. 支持**HTTPS和HTTP/2**
 6. **PHP源代码、MySQL数据、配置文件、日志文件**都可在Host中直接修改查看
 7. 内置**完整PHP扩展安装**命令
 8. 默认支持`pdo_mysql`、`mysqli`、`mbstring`、`gd`、`curl`、`opcache`等常用热门扩展，根据环境灵活配置
 9. 可一键选配常用服务：
-    - 多PHP版本：PHP5.4、PHP5.6、PHP7.1-7.3、PHP8.0
+    - 多PHP版本：PHP5.4、PHP5.6、PHP7.0-7.4、PHP8.0
     - Web服务：Nginx、Openresty
     - 数据库：MySQL5、MySQL8、Redis、memcached、MongoDB、ElasticSearch
     - 消息队列：RabbitMQ
@@ -30,6 +30,7 @@ DNMP项目特点：
 11. 所有镜像源于[Docker官方仓库](https://hub.docker.com)，安全可靠
 11. 一次配置，**Windows、Linux、MacOs**皆可用
 12. 支持快速安装扩展命令 `install-php-extensions apcu`
+13. 支持安装certbot获取免费https用的SSL证书
 
 # 目录
 - [1.目录结构](#1目录结构)
@@ -72,7 +73,7 @@ DNMP项目特点：
 │   ├── mysql                   MySQL8 配置文件目录
 │   ├── mysql5                  MySQL5 配置文件目录
 │   ├── nginx                   Nginx 配置文件目录
-│   ├── php                     PHP5.6 - PHP7.3 配置目录
+│   ├── php                     PHP5.6 - PHP7.4 配置目录
 │   ├── php54                   PHP5.4 配置目录
 │   └── redis                   Redis 配置目录
 ├── logs                        日志目录
@@ -89,6 +90,8 @@ DNMP项目特点：
 2. `clone`项目：
     ```
     $ git clone https://github.com/yeszao/dnmp.git
+    # 假如速度太慢，可以使用加速拉取镜像
+    $ git clone https://github.com.cnpmjs.org/yeszao/dnmp.git
     ```
 3. 如果主机是 Linux系统，且当前用户不是`root`用户，还需将当前用户加入`docker`用户组：
     ```
@@ -320,8 +323,8 @@ install-php-extensions apcu
         "repositories": {
             "packagist": {
                 "type": "composer",
-                "url": "https://packagist.laravel-china.org"
-            }
+                "url": "https://mirrors.aliyun.com/composer/"
+s            }
         }
     }
 

--- a/docker-compose.sample.yml
+++ b/docker-compose.sample.yml
@@ -24,6 +24,9 @@ services:
     restart: always
     networks:
       - default
+      # 可以把-default 改成下列配置，以固定容器IP
+      #default:
+      #  ipv4_address: 10.0.0.10
 
   php:
     build:
@@ -118,7 +121,7 @@ services:
 #      - default
 
   mysql:
-    image: mysql:${MYSQL_VERSION}
+    image: mysql/mysql-server:${MYSQL_VERSION}
     container_name: mysql
     ports:
       - "${MYSQL_HOST_PORT}:3306"
@@ -130,6 +133,7 @@ services:
       - default
     environment:
       MYSQL_ROOT_PASSWORD: "${MYSQL_ROOT_PASSWORD}"
+      MYSQL_ROOT_HOST: "${MYSQL_ROOT_HOST}"
       TZ: "$TZ"
 
 #  mysql5:
@@ -354,3 +358,9 @@ services:
 
 networks:
   default:
+    driver: bridge
+    ipam:
+      driver: default
+      # 解除下面的注释可以设置网段，用于nginx等容器固定容器IP
+      #config:
+      #  - subnet: 10.0.0.0/24

--- a/env.sample
+++ b/env.sample
@@ -110,7 +110,7 @@ PHP80_EXTENSIONS=pdo_mysql,mysqli,mbstring,gd,curl,opcache
 # or install multi plugins as:
 # PHP_EXTENSIONS=pdo_mysql,mysqli,gd,curl,opcache
 #
-PHP_VERSION=7.4.7
+PHP_VERSION=7.4.27
 PHP_PHP_CONF_FILE=./services/php/php.ini
 PHP_FPM_CONF_FILE=./services/php/php-fpm.conf
 PHP_LOG_DIR=./logs/php
@@ -202,9 +202,10 @@ LOGSTASH_HOST_PORT_S=5044
 #
 # MySQL8
 #
-MYSQL_VERSION=8.0.27
+MYSQL_VERSION=8.0.28
 MYSQL_HOST_PORT=3306
 MYSQL_ROOT_PASSWORD=123456
+MYSQL_ROOT_HOST=%
 MYSQL_CONF_FILE=./services/mysql/mysql.cnf
 
 #


### PR DESCRIPTION
- 优化部分文档：优化细节、增加clone用镜像地址、增加certbot介绍、composer镜像切换成阿里云
- 增加固定容器IP配置示例
- MySQL支持Arm CPU，支持初始化root账户的host配置，方便外部直连
- 更新MySQL 8.0.27 -> 8.0.28
- 更新PHP 7.4.7 -> 7.4.27