### PR TITLE
fixed:php80 xdebug

### DIFF
--- a/services/php80/php.ini
+++ b/services/php80/php.ini
@@ -1918,10 +1918,10 @@ ldap.max_links = -1
 ; End:
 
 [XDebug]
-xdebug.remote_enable = 1
+xdebug.mode=debug
 xdebug.remote_handler = "dbgp"
 ; Set to host.docker.internal on Mac and Windows, otherwise, set to host real ip
-xdebug.remote_host = host.docker.internal
+xdebug.client_host = host.docker.internal
 ;xdebug.remote_port = 9000
 xdebug.remote_log = /var/log/php/xdebug.log
 


### PR DESCRIPTION
`Xdebug3` 与 `Xdebug 2` 的 `php.ini` 配置不同，详情请看
https://www.jetbrains.com/help/phpstorm/2021.3/configuring-xdebug.html#updatingPhpIni