### PR TITLE
fix swoole install

### DIFF
--- a/services/php/extensions/install.sh
+++ b/services/php/extensions/install.sh
@@ -607,6 +607,9 @@ fi
 
 if [[ -z "${EXTENSIONS##*,swoole,*}" ]]; then
     echo "---------- Install swoole ----------"
+    # Fix: Refer to the line containing "swoole@alpine)" in file "./install-php-extensions"
+    apk add --no-cache libstdc++
+
     isPhpVersionGreaterOrEqual 7 0
 
     if [[ "$?" = "1" ]]; then


### PR DESCRIPTION
fix issue：https://github.com/yeszao/dnmp/issues/509

```
/www # php --ri swoole

swoole

Swoole => enabled
Author => Swoole Team <team@swoole.com>
Version => 4.5.2
Built => Dec 19 2022 02:10:18
coroutine => enabled
epoll => enabled
eventfd => enabled
signalfd => enabled
spinlock => enabled
rwlock => enabled
zlib => 1.2.12
brotli => E16777225/D16777225
mutex_timedlock => enabled
pthread_barrier => enabled
futex => enabled
async_redis => enabled

Directive => Local Value => Master Value
swoole.enable_coroutine => On => On
swoole.enable_library => On => On
swoole.enable_preemptive_scheduler => Off => Off
swoole.display_errors => On => On
swoole.use_shortname => On => On
swoole.unixsock_buffer_size => 8388608 => 8388608
```