### PR TITLE
修复mysql配置文件无法使用的问题

### DIFF
--- a/docker-compose.sample.yml
+++ b/docker-compose.sample.yml
@@ -121,7 +121,7 @@ services:
 #      - default
 
   mysql:
-    image: mysql/mysql-server:${MYSQL_VERSION}
+    image: mysql:${MYSQL_VERSION}
     container_name: mysql
     ports:
       - "${MYSQL_HOST_PORT}:3306"
@@ -139,7 +139,7 @@ services:
       TZ: "$TZ"
 
   mysql5:
-    image: mysql/mysql-server:${MYSQL5_VERSION}
+    image: mysql:${MYSQL5_VERSION}
     container_name: mysql5
     ports:
       - "${MYSQL5_HOST_PORT}:3306"

--- a/env.sample
+++ b/env.sample
@@ -84,7 +84,7 @@ SUPERVISOR_HOST_PORT_C=9001
 # or install multi plugins as:
 # PHP_EXTENSIONS=pdo_mysql,mysqli,gd,curl,opcache
 #
-PHP80_VERSION=8.0.9
+PHP80_VERSION=8.0.29
 PHP80_PHP_CONF_FILE=./services/php80/php.ini
 PHP80_FPM_CONF_FILE=./services/php80/php-fpm.conf
 PHP80_LOG_DIR=./logs/php80
@@ -110,7 +110,7 @@ PHP80_EXTENSIONS=pdo_mysql,mysqli,mbstring,gd,curl,opcache
 # or install multi plugins as:
 # PHP_EXTENSIONS=pdo_mysql,mysqli,gd,curl,opcache
 #
-PHP_VERSION=7.4.27
+PHP_VERSION=7.4.33
 PHP_PHP_CONF_FILE=./services/php/php.ini
 PHP_FPM_CONF_FILE=./services/php/php-fpm.conf
 PHP_LOG_DIR=./logs/php
@@ -202,7 +202,7 @@ LOGSTASH_HOST_PORT_S=5044
 #
 # MySQL8
 #
-MYSQL_VERSION=8.0.28
+MYSQL_VERSION=8.0.34
 MYSQL_HOST_PORT=3306
 MYSQL_ROOT_PASSWORD=123456
 MYSQL_ROOT_HOST=%
@@ -211,7 +211,7 @@ MYSQL_LOG_DIR=./logs/mysql
 #
 # MySQL5
 #
-MYSQL5_VERSION=5.7.28
+MYSQL5_VERSION=5.7.42
 MYSQL5_HOST_PORT=3305
 MYSQL5_ROOT_PASSWORD=123456
 MYSQL5_ROOT_HOST=%


### PR DESCRIPTION
1.修复之前的mysql.conf一直无法被正确使用的bug
2.自8.0.29,mysql仓库已支持linux/arm64v8,而mysql-server仓库已半年未更新，显然官方已放弃维护