### PR TITLE
611 fix nginx php82 volumes www

### DIFF
--- a/bash.alias.sample
+++ b/bash.alias.sample
@@ -1,6 +1,6 @@
 # dnmp alias
 alias dnginx='docker exec -it nginx /bin/sh'
-alias dphp='docker exec -it php /bin/sh'
+alias dphp='docker exec -it php80 /bin/sh'
 alias dphp56='docker exec -it php56 /bin/sh'
 alias dphp54='docker exec -it php54 /bin/sh'
 alias dmysql='docker exec -it mysql /bin/bash'
@@ -16,7 +16,7 @@ php () {
         --rm \
         --volume $PWD:/www:rw \
         --workdir /www \
-        dnmp_php php "$@"
+        dnmp_php php74 "$@"
 }
 
 # php5.6 cli

--- a/bash.alias.sample
+++ b/bash.alias.sample
@@ -1,11 +1,23 @@
 # dnmp alias
 alias dnginx='docker exec -it nginx /bin/sh'
-alias dphp='docker exec -it php80 /bin/sh'
+alias dphp='docker exec -it php82 /bin/sh'
 alias dphp56='docker exec -it php56 /bin/sh'
 alias dphp54='docker exec -it php54 /bin/sh'
 alias dmysql='docker exec -it mysql /bin/bash'
 alias dredis='docker exec -it redis /bin/sh'
 
+# php8 cli
+php80 () {
+    tty=
+    tty -s && tty=--tty
+    docker run \
+        $tty \
+        --interactive \
+        --rm \
+        --volume $PWD:/www:rw \
+        --workdir /www \
+        dnmp_php php80 "$@"
+}
 # php7 cli
 php () {
     tty=

--- a/docker-compose.sample.yml
+++ b/docker-compose.sample.yml
@@ -8,7 +8,7 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - ./www:/www
+      - ${SOURCE_DIR}:/www/:rw
       - ./services/nginx/ssl:/ssl
       - ./services/nginx/conf.d:/etc/nginx/conf.d
       - ./services/nginx/nginx.conf:/etc/nginx/nginx.conf
@@ -30,7 +30,7 @@ services:
     expose:
       - 9501
     volumes:
-      - ./www:/www
+      - ${SOURCE_DIR}:/www/:rw
       - ./services/php82/php.ini:/usr/local/etc/php/php.ini
       - ./services/php82/php-fpm.conf:/usr/local/etc/php-fpm.d/www.conf
       - ./logs/php82:/var/log/php


### PR DESCRIPTION
1. 修复 docker-compose.sample.yml 文件增加nginx 和php82容器挂载 www 目录没有使用${SOURCE_DIR}变量问题
2. 增加 bash.alias.sample  php8 cli命令支持
3. 修改 dphp 默认容器为 php82